### PR TITLE
make axe-core/cli work again

### DIFF
--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -15,10 +15,25 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
+      - name: Get Chromium version 🌐
+        run: |
+          CHROMIUM_VERSION=$(wget -qO- https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE | cut -d. -f1)
+          echo "Chromium version: $CHROMIUM_VERSION"
+          echo "CHROMIUM_VERSION=$CHROMIUM_VERSION" >> $GITHUB_ENV
+      - name: Setup Chrome 🌐
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: ${{ env.CHROMIUM_VERSION }}
+      - name: Install chromedriver 🚗
+        run: |
+          echo "Installing chromedriver version: $CHROMIUM_VERSION"
+          yarn add chromedriver@$CHROMIUM_VERSION
+          echo "chromedriver version: $(chromedriver --version)"
+      - run: npm install
       - run: npm run build --if-present
       - run: npm start & npx wait-on http://localhost:8080
       - name: Run axe
         run: |
-          npm install -g @axe-core/cli@4.10.0
+          npm install -g @axe-core/cli
           axe http://localhost:8080/documentation/images/ --exit

--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Get Chromium version 🌐
         run: |
           CHROMIUM_VERSION=$(wget -qO- https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE | cut -d. -f1)
-          echo "Chromium version: $CHROMIUM_VERSION"
+          echo "Chromium 🌐 version: $CHROMIUM_VERSION"
           echo "CHROMIUM_VERSION=$CHROMIUM_VERSION" >> $GITHUB_ENV
       - name: Setup Chrome 🌐
         id: setup-chrome
@@ -36,4 +36,6 @@ jobs:
       - name: Run axe
         run: |
           npm install -g @axe-core/cli
+          CHROMIUM_VERSION=$(google-chrome --version | cut -d' ' -f3 | cut -d'.' -f1)
+          npm install chromedriver@$CHROMIUM_VERSION
           axe http://localhost:8080/documentation/images/ --exit

--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      pull-requests: none
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -25,5 +25,5 @@ jobs:
       - run: npm start & npx wait-on http://localhost:8080
       - name: Run axe 🪓
         run: |
-          npm install -g @axe-core/cli
+          npm install -g @axe-core/cli@4.10.2-e53cd36.0
           axe http://localhost:8080/documentation/images/ --exit

--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -15,27 +15,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Get Chromium version 🌐
-        run: |
-          CHROMIUM_VERSION=$(wget -qO- https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE | cut -d. -f1)
-          echo "Chromium 🌐 version: $CHROMIUM_VERSION"
-          echo "CHROMIUM_VERSION=$CHROMIUM_VERSION" >> $GITHUB_ENV
-      - name: Setup Chrome 🌐
-        id: setup-chrome
-        uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: ${{ env.CHROMIUM_VERSION }}
-      - name: Install chromedriver 🚗
-        run: |
-          echo "Installing chromedriver version: $CHROMIUM_VERSION"
-          yarn add chromedriver@$CHROMIUM_VERSION
-          echo "chromedriver version: $(chromedriver --version)"
       - run: npm install
       - run: npm run build --if-present
       - run: npm start & npx wait-on http://localhost:8080
       - name: Run axe
         run: |
           npm install -g @axe-core/cli
-          CHROMIUM_VERSION=$(google-chrome --version | cut -d' ' -f3 | cut -d'.' -f1)
-          npm install chromedriver@$CHROMIUM_VERSION
+          npm install -g browser-driver-manager
+          npx browser-driver-manager install chrome
           axe http://localhost:8080/documentation/images/ --exit

--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -16,11 +16,14 @@ jobs:
         with:
           node-version: 20
       - run: npm install
-      - run: npm run build --if-present
-      - run: npm start & npx wait-on http://localhost:8080
-      - name: Run axe
+      - name: install chrome 🌐
         run: |
-          npm install -g @axe-core/cli
           npm install -g browser-driver-manager
           npx browser-driver-manager install chrome
+      - name: build 🛠️
+        run: npm run build --if-present
+      - run: npm start & npx wait-on http://localhost:8080
+      - name: Run axe 🪓
+        run: |
+          npm install -g @axe-core/cli
           axe http://localhost:8080/documentation/images/ --exit

--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -20,5 +20,5 @@ jobs:
       - run: npm start & npx wait-on http://localhost:8080
       - name: Run axe
         run: |
-          npm install -g @axe-core/cli@4.10.1
+          npm install -g @axe-core/cli@4.10.0
           axe http://localhost:8080/documentation/images/ --exit


### PR DESCRIPTION
Trying to fix the issue 
```
"Error: session not created: This version of ChromeDriver only supports Chrome version 121 Current browser version is 120.0.6099.224 with binary path /opt/google/chrome/chrome
```
also referenced [here](https://stackoverflow.com/questions/77883031/github-actions-pipeline-failure-with-axe-core-cli)

added chrome but end up with the issue:
```
Error: SessionNotCreatedError: session not created: probably user data directory is already in use, please specify a unique value for --user-data-dir argument, or don't use --user-data-dir
    at Object.throwDecodedError (/opt/hostedtoolcache/node/20.18.3/x64/lib/node_modules/@axe-core/cli/node_modules/selenium-webdriver/lib/error.js:521:15)
```

This error was reported to Selenium https://github.com/SeleniumHQ/selenium/issues/14609

and was fixed in the patch  [ci: resolve chromedrivers not running in Ubuntu runners >=24.04](https://github.com/dequelabs/axe-core-npm/pull/1150) on axe-core-npm.

It looks like updating to the latest version of `axe-core/cli@4.10.2-e53cd36.0` solves the last issue.